### PR TITLE
Update application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,10 +53,6 @@ module Chatwoot
     # FIX ME : fixes breakage of installation config. we need to migrate.
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 
-    # Adiciona cabeçalho para permitir iframes
-    config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'ALLOWALL'
-    }
   end
 
   def self.config


### PR DESCRIPTION
Essa parte foi removida devido ao desuso do header X-frame-options. "ALLOWALL" não existe mais e remete ao padrão "SAMEORIGIN", impedindo a implementação de dashboard apps.